### PR TITLE
added support for the user and service authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The `parse_llm_response()` function parses an LLM response searching for API cal
 
 ### Call API
 
-The `call_api()` function calls an operation in an active plugin. It takes the plugin name, operation ID, and parameters extracted by `parse_llm_response()` and makes a request to the plugin API. When you want to use the plugin which is having the user or service level authentication pass api_key(string) as parameter.
+The `call_api()` function calls an operation in an active plugin. It takes the plugin name, operation ID, and parameters extracted by `parse_llm_response()` and makes a request to the plugin API. When you want to use the plugin which is having the user or service level or oauth level authentication pass api_key(string) as parameter. For oauth pass the access_token as a api_key parameter. For more detail about oauth authentication please see examples/run_plugin.py and examples/server.py files.
 
 
 ### Apply Plugins

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The `parse_llm_response()` function parses an LLM response searching for API cal
 
 ### Call API
 
-The `call_api()` function calls an operation in an active plugin. It takes the plugin name, operation ID, and parameters extracted by `parse_llm_response()` and makes a request to the plugin API.
+The `call_api()` function calls an operation in an active plugin. It takes the plugin name, operation ID, and parameters extracted by `parse_llm_response()` and makes a request to the plugin API. When you want to use the plugin which is having the user or service level authentication pass api_key(string) as parameter.
 
 
 ### Apply Plugins

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It provides utility functions to get a list of active plugins from [plugnplai.co
 
 ## Installation
 
-You can install Plug and PlAI using pip:
+You can install Plug and Plai using pip:
 
 ```python
 pip install plugnplai

--- a/README.md
+++ b/README.md
@@ -136,7 +136,9 @@ The `parse_llm_response()` function parses an LLM response searching for API cal
 
 ### Call API
 
-The `call_api()` function calls an operation in an active plugin. It takes the plugin name, operation ID, and parameters extracted by `parse_llm_response()` and makes a request to the plugin API. When you want to use the plugin which is having the user or service level or oauth level authentication pass api_key(string) as parameter. For oauth pass the access_token as a api_key parameter. For more detail about oauth authentication please see examples/run_plugin.py and examples/server.py files.
+The `call_api()` function calls an operation in an active plugin. It takes the plugin name, operation ID, and parameters extracted by `parse_llm_response()` and makes a request to the plugin API. 
+
+**Plugin Authentication:** Plugins with Oauth, user or service level authentication pass api_key(string) as parameter. For oauth, use the access_token as the api_key parameter. For more detail about oauth authentication please see [examples/plugin_with_oauth.py](https://github.com/edreisMD/plugnplai/tree/master/examples/plugin_with_auth.py) and [examples/oauth_server.py](https://github.com/edreisMD/plugnplai/tree/master/examples/oauth_server.py) files.
 
 
 ### Apply Plugins

--- a/examples/run_plugin.py
+++ b/examples/run_plugin.py
@@ -1,0 +1,124 @@
+# run server.py first
+# this file is the example for the retry mechanism with asana plugin.
+# enter the access_token when your plugin is using the oauth authentication.
+
+import guidance
+
+guidance.llm = guidance.llms.OpenAI("gpt-4", token="openai_api_key")
+import plugnplai
+
+
+def send_single_user_request(system_prompt, user_message):
+    send_single_user_request = guidance(
+        '''
+        {{#system~}}
+        {{system_prompt}}
+        {{~/system}}
+
+        {{#user~}}
+        {{user_message}}
+        {{~/user}}
+
+        {{#assistant~}}
+        {{gen 'assistant_response' temperature=0 max_tokens=300}}
+        {{~/assistant}}'''
+    )
+    return send_single_user_request(system_prompt=system_prompt, user_message=user_message)
+
+
+def api_return_message(user_message, llm_first_response, api_response):
+    create_api_return_message = guidance(
+        '''
+        {{#user~}}
+        {{user_message}}
+        {{~/user}}
+
+        {{#system~}}
+        Assistant is a large language model with access to plugins.
+
+        Assistant called a plugin in response to previous user message.
+        # API REQUEST SUMMARY
+        {{llm_first_response}}
+
+        # API RESPONSE
+        {{api_response}}
+        {{~/system}}
+
+        {{#assistant~}}
+        {{gen 'assistant_response' temperature=0 max_tokens=300}}
+        {{~/assistant}}'''
+    )
+    return create_api_return_message(
+        user_message=user_message, llm_first_response=llm_first_response, api_response=api_response
+    )
+
+
+if __name__ == '__main__':
+
+    user_inputs_query = "Create a task in Asana with the title 'Prepare presentation' and due date '2023-05-25' in workspace id 1"
+    # Use the correct URL
+    url_of_plugin_to_test = "https://app.asana.com"
+
+    api_key = input("input your api key: ")
+
+    print('\n----\n1 -> Entered Process\n')
+
+    urls = [url_of_plugin_to_test]
+    # urls.append(url_of_plugin_to_test)
+    plugins = plugnplai.Plugins.install_and_activate(urls)
+
+    print('\n----\n2 -> Plugin Prompt\n')
+
+    print(plugins.prompt)
+
+    print('\n----\n3 -> User Query\n')
+    user_first_message = user_inputs_query
+    print(user_first_message)
+
+    assistant_first_response = send_single_user_request(system_prompt=plugins.prompt, user_message=user_first_message)
+
+    llm_first_response = assistant_first_response['assistant_response']
+
+    print('\n----\n4 -> Assistant First Response\n')
+    print(llm_first_response)
+
+    print('\n----\n5 -> API Call Dict\n')
+    call_dict = plugnplai.parse_llm_response(llm_first_response)
+    print(call_dict)
+
+
+    # pass the access_token as api_key incase of the oauth technique.
+    api_response = plugins.call_api(
+        plugin_name=call_dict['plugin_name'], operation_id=call_dict['operation_id'], parameters=call_dict['parameters'],
+        url=url_of_plugin_to_test,
+        api_key=api_key
+    )
+
+    # ---------------------------------RETRY MECHANISM-----------------------------------------------------#
+    # retry mechanism when access_token is expired.
+    if "token has expired" in response.text:
+
+        # ------------------------------REPLACE WITH ORIGINAL VALUES---------------------------------------#
+        client_id = "client_id"
+        client_secret = "client_secret"
+        req_url = "authorization_token_url"
+        refresh_token = "refresh_token"
+
+        # make a request to a sever ( to a authorization_url ) with a grant type as a refresh_token.
+        try:
+            res = requests.post(req_url, params={"client_id":client_id, "client_secret":client_secret, "refresh_token":refresh_token, "grant_type": "refresh_token"})
+        except Exception as e:
+            print(f"something went wrong {e}")
+            return "Something went wrong please relogin"
+        token_obj = res.json()
+        print(token_obj)
+        api_key = token_obj["access_token"]
+        api_response = plugins.call_api(
+            plugin_name=call_dict['plugin_name'], operation_id=call_dict['operation_id'], parameters=call_dict['parameters'],
+            url=url_of_plugin_to_test,
+            api_key=api_key
+        )
+        
+
+    print('\n----\n6 -> API Response\n')
+    print(api_response)

--- a/examples/server.py
+++ b/examples/server.py
@@ -1,0 +1,57 @@
+# This file is example for the handling the login with oauth authentication.
+# it has two endpoints 
+# 1. /login : it is used for redirecting the user to a aunthentication_url(you can get this deatils from the mantifest file) of particular plugin.
+# 2. /callback : it is called automatically on success or failure response of the /login endpoint.
+# requirements.
+# pip install requests_oauthlib
+# run this file first.
+
+
+import json
+from urllib.parse import urljoin
+
+from requests_oauthlib import OAuth2Session
+from flask import Flask, request, session, redirect
+import ssl
+
+redirect_uri = 'https://localhost:5000/callback'
+app = Flask(__name__)
+app.secret_key = "qazwsx"
+# Update the SSL context with the certificate and key file paths
+
+context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+# add the certificate and key from the pyopenssl or generate it.
+context.load_cert_chain(certfile='certificate.crt', keyfile='private.key')
+client_id = "client_id"
+client_secret = "client_secret"
+client_url = "client_url" 
+token_url = "authorization_token_url"
+
+@app.route('/login', methods=["GET"])
+def login():
+    try:
+        global oauth
+        oauth = OAuth2Session(client_id, redirect_uri=redirect_uri)
+        authorization_url, state = oauth.authorization_url(client_url)
+        session['oauth_state'] = state
+        return redirect(authorization_url)
+    except Exception as e:
+        print(e)
+
+
+@app.route('/callback')
+def callback():
+    if 'error' in request.args:
+        return 'Error: ' + request.args['error']
+
+    token = oauth.fetch_token(
+        token_url,
+        client_secret=client_secret,
+        code=request.args.get("code", "")
+    )
+
+    return token
+
+
+if __name__ == '__main__':
+    app.run(debug=True, ssl_context=context)

--- a/plugnplai/plugins.py
+++ b/plugnplai/plugins.py
@@ -488,6 +488,8 @@ class Plugins:
             The ID of the operation to call.
         parameters : dict
             The parameters to pass to the operation.
+        api_key : str, optional
+            The api key for authentication.
             
         Returns
         -------

--- a/plugnplai/plugins.py
+++ b/plugnplai/plugins.py
@@ -215,8 +215,7 @@ class PluginObject():
         for name, value in path_parameters.items():
             url = url.replace('{' + name + '}', str(value))
 
-        is_user_http = self.manifest.get("auth", {}).get("type", "")
-        if is_user_http:
+        if self.manifest.get("auth", {}).get("type", "").lower() in ("service_http", "user_http", "oauth"):
             header_parameters["Authorization"] = f"Bearer {api_key}"
             header_parameters["Accept"] = "application/json"
 

--- a/plugnplai/plugins.py
+++ b/plugnplai/plugins.py
@@ -168,7 +168,7 @@ class PluginObject():
 
         return operation_details_dict
 
-    def call_operation(self, operation_id: str, parameters: Dict[str, Any], original_url, api_key, user_id):
+    def call_operation(self, operation_id: str, parameters: Dict[str, Any], api_key: str = None):
         """Call an operation in the plugin.
         
         Parameters
@@ -177,6 +177,8 @@ class PluginObject():
             The ID of the operation to call.
         parameters : dict
             The parameters to pass to the operation.
+        api_key : str, optional
+            The api key for authentication.
             
         Returns
         -------
@@ -232,6 +234,14 @@ class PluginObject():
 
 
     def describe_api(self) -> str:
+        """Generate a prompt describing the plugin operations.
+        
+        Returns
+        -------
+        str
+            The generated prompt.
+        """
+        
         # Template for the whole API description
         api_template = '// {description_for_model}\nnamespace {name_for_model} {{{operations}}}'
         
@@ -466,7 +476,7 @@ class Plugins:
 
         return prompt
 
-    def call_api(self, plugin_name: str, operation_id: str, parameters: Dict[str, Any], url=None, api_key=None, user_id=None) -> Optional[
+    def call_api(self, plugin_name: str, operation_id: str, parameters: Dict[str, Any], api_key: str = None) -> Optional[
         requests.Response]:
         """Call an operation in an active plugin.
         
@@ -499,7 +509,7 @@ class Plugins:
             return None
 
         # Call the operation
-        response = openapi_object.call_operation(operation_id, parameters, url, api_key, user_id)
+        response = openapi_object.call_operation(operation_id, parameters, api_key)
 
         return response
 


### PR DESCRIPTION
Hello Team,
As per the documentation of the openai, we have 3 types of authentication supported for the user and service level auth. as per the documentation, we know that we need to pass the api_key in the header as a Bearer token. i have adde the condition for that.

FYI : For the POST request when you are passing the parameter which is coming to a call_api function i have found that it was not being passed while tested to i have changed those.

I have added the oauth support in my local. it need to be reviewed first let me know once any of you are available. i am happy to discuss.